### PR TITLE
Prototype: Non-hydrated to hydrated "dots" transition (Reduce LCP/SpeedIndex impact)

### DIFF
--- a/components/SplashScreen.dots/SplashScreen.css
+++ b/components/SplashScreen.dots/SplashScreen.css
@@ -1,0 +1,91 @@
+.SplashScreen {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	gap: 16px;
+	position: fixed;
+	top: 0px;
+	right: 0px;
+	left: 0px;
+	bottom: 0px;
+	z-index: 99999;
+	opacity: 1;
+}
+
+.SplashScreen--hidden {
+	pointer-events: none;
+	animation: SplashScreen-hide 500ms forwards;
+}
+
+@keyframes SplashScreen-hide {
+	from {
+		opacity: 1;
+	}
+	to {
+		opacity: 0;
+	}
+}
+
+.SplashScreen__loader {
+	display: inline-block;
+	position: relative;
+	width: 72px;
+	height: 10px;
+}
+
+.SplashScreen__dot {
+	position: absolute;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: var(--vpss-bg-loader, #00a2c7);
+	animation-timing-function: cubic-bezier(0, 1, 1, 0);
+}
+
+.SplashScreen__loader .SplashScreen__dot:nth-child(1) {
+	left: 8px;
+	animation: SplashScreen-dot1 0.6s infinite;
+}
+
+.SplashScreen__loader .SplashScreen__dot:nth-child(2) {
+	left: 8px;
+	animation: SplashScreen-dot2 0.6s infinite;
+}
+
+.SplashScreen__loader .SplashScreen__dot:nth-child(3) {
+	left: 32px;
+	animation: SplashScreen-dot2 0.6s infinite;
+}
+
+.SplashScreen__loader .SplashScreen__dot:nth-child(4) {
+	left: 56px;
+	animation: SplashScreen-dot3 0.6s infinite;
+}
+
+@keyframes SplashScreen-dot1 {
+	0% {
+		transform: scale(0);
+	}
+	100% {
+		transform: scale(1);
+	}
+}
+
+@keyframes SplashScreen-dot2 {
+	0% {
+		transform: translate(0, 0);
+	}
+	100% {
+		transform: translate(24px, 0);
+	}
+}
+
+@keyframes SplashScreen-dot3 {
+	0% {
+		transform: scale(1);
+	}
+	100% {
+		transform: scale(0);
+	}
+}

--- a/components/SplashScreen.dots/SplashScreen.tsx
+++ b/components/SplashScreen.dots/SplashScreen.tsx
@@ -1,0 +1,105 @@
+import {
+	useEffect,
+	useState,
+	type CSSProperties,
+	useRef,
+	useImperativeHandle,
+	forwardRef,
+} from "react";
+
+import "./SplashScreen.css";
+
+export interface SplashScreenHandle {
+	hide: () => void;
+}
+
+interface SplashScreenProps {
+	minDurationMs?: number;
+	onHidden?: () => void; // Callback when fully hidden and removed
+}
+
+const SplashScreen = forwardRef<SplashScreenHandle, SplashScreenProps>(
+	({ minDurationMs = 0, onHidden }, ref) => {
+		const [status, setStatus] = useState<"pending" | "visible" | "hiding" | "hidden">("pending");
+		const elementRef = useRef<HTMLDivElement>(null);
+		const renderedAtRef = useRef<number>(0);
+		const cssBlock = "SplashScreen"; // BEM Block name, also used for URL param
+
+		useEffect(() => {
+			renderedAtRef.current = new Date().getTime();
+			const url = new URL(window.location.href);
+			const urlParams = new URLSearchParams(url.search);
+			const param = urlParams.get(cssBlock); // Check for ?SplashScreen=false
+
+			let shouldBeVisible = true;
+			if (param === "false") {
+				shouldBeVisible = false;
+			}
+
+			if (param) {
+				urlParams.delete(cssBlock);
+				url.search = urlParams.toString();
+				window.history.replaceState({}, "", url.toString());
+			}
+
+			setStatus(shouldBeVisible ? "visible" : "hidden");
+		}, [cssBlock]);
+
+		useImperativeHandle(ref, () => ({
+			async hide() {
+				if (status !== "visible" || !elementRef.current) return;
+
+				const elapsedTime = new Date().getTime() - renderedAtRef.current;
+				const remainingTime = Math.max(minDurationMs - elapsedTime, 0);
+
+				if (remainingTime > 0) {
+					await new Promise((resolve) => setTimeout(resolve, remainingTime));
+				}
+				setStatus("hiding");
+			},
+		}));
+
+		useEffect(() => {
+			const element = elementRef.current;
+			if (status === "hiding" && element) {
+				const handleAnimationEnd = (event: AnimationEvent) => {
+					if (event.animationName === `${cssBlock}-hide`) {
+						setStatus("hidden");
+						onHidden?.();
+						element.removeEventListener("animationend", handleAnimationEnd as EventListener);
+					}
+				};
+				element.addEventListener("animationend", handleAnimationEnd as EventListener);
+				element.classList.add(`${cssBlock}--hidden`); // Trigger animation
+
+				return () => {
+					element.removeEventListener("animationend", handleAnimationEnd as EventListener);
+				};
+			}
+		}, [status, cssBlock, onHidden]);
+
+		if (status === "hidden" || status === "pending") {
+			return null;
+		}
+
+		return (
+			<>
+				<div
+					className={cssBlock}
+					ref={elementRef}
+					style={{ visibility: "visible" } as CSSProperties} // Made visible by JS when status is 'visible'
+				>
+					<div className={`${cssBlock}__loader`}>
+						<div className={`${cssBlock}__dot`}></div>
+						<div className={`${cssBlock}__dot`}></div>
+						<div className={`${cssBlock}__dot`}></div>
+						<div className={`${cssBlock}__dot`}></div>
+					</div>
+				</div>
+			</>
+		);
+	}
+);
+
+SplashScreen.displayName = "SplashScreen";
+export default SplashScreen;


### PR DESCRIPTION
For my project ([nms-optimizer.app](https://nms-optimizer.app/)), I explored a seamless transition from the non-hydrated to the hydrated version of the "dots" presentation to maintain visual consistency as the app transitioned states. Overall, your plugin gave me a nice boost—Lighthouse reported a 99 in performance.

Unfortunately, the layout shift between the non-hydrated and hydrated versions was still too noticeable, mostly due to the CSS hacks needed for iOS Safari and background image handling vs positioning.

That said, I’m including a copy of what I put together in case it’s useful. It’s not perfect—I had to namespace the CSS separately to avoid conflicts—but it might serve as a helpful reference or starting point if you ever explore component-based versions of this pattern.